### PR TITLE
Add minimal React app with Vite and d3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+dist/
+.env

--- a/README
+++ b/README
@@ -1,0 +1,49 @@
+# WorldMetrics React Setup
+
+This repository contains a minimal React application powered by [Vite](https://vitejs.dev/) and includes [D3.js](https://d3js.org/) for data visualization. Use it as a starting point for integrating other frontend libraries.
+
+## Prerequisites
+
+- [Node.js](https://nodejs.org/) (version 16 or higher recommended)
+- [npm](https://www.npmjs.com/) or [yarn](https://yarnpkg.com/) package manager
+
+## Installation
+
+1. Install dependencies:
+   ```bash
+   npm install
+   # or
+   yarn install
+   ```
+
+2. Start the development server:
+   ```bash
+   npm run dev
+   # or
+   yarn dev
+   ```
+
+3. Open your browser to the address printed in the console (usually `http://localhost:5173`). The page should display a blue circle rendered with D3.js.
+
+## Building for Production
+
+To create a production build:
+```bash
+npm run build
+# or
+yarn build
+```
+The compiled files will be placed in the `dist/` directory.
+
+## Previewing the Build
+
+After building, you can preview the production build locally:
+```bash
+npm run preview
+# or
+yarn preview
+```
+
+## Adding Other Libraries
+
+Install any additional libraries with `npm install <package>` or `yarn add <package>`, then import them into your React components as needed.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "worldmetrics-app",
+  "version": "1.0.0",
+  "private": true,
+  "description": "A basic React setup with D3.js and other frontend libraries.",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "d3": "^7.9.0"
+  },
+  "devDependencies": {
+    "vite": "^4.4.9",
+    "@vitejs/plugin-react": "^4.0.1"
+  }
+}

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>WorldMetrics App</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/src/App.css
+++ b/src/App.css
@@ -1,0 +1,4 @@
+.App {
+  padding: 20px;
+  text-align: center;
+}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import * as d3 from 'd3';
+import './App.css';
+
+export default function App() {
+  React.useEffect(() => {
+    const svg = d3.select('#viz')
+      .append('svg')
+      .attr('width', 200)
+      .attr('height', 200);
+
+    svg.append('circle')
+      .attr('cx', 100)
+      .attr('cy', 100)
+      .attr('r', 80)
+      .attr('fill', 'steelblue');
+  }, []);
+
+  return (
+    <div className="App">
+      <h1>WorldMetrics React + D3</h1>
+      <div id="viz"></div>
+    </div>
+  );
+}

--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,4 @@
+body {
+  margin: 0;
+  font-family: Arial, Helvetica, sans-serif;
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import './index.css';
+
+const root = ReactDOM.createRoot(document.getElementById('root'));
+root.render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    open: true
+  }
+});


### PR DESCRIPTION
## Summary
- initialize React app using Vite
- include d3 and example visualization
- add development and build scripts
- document how to install dependencies and run the project

## Testing
- `npm test` *(fails: Missing script)*