### PR TITLE
Add prestart script

### DIFF
--- a/README
+++ b/README
@@ -18,10 +18,14 @@ This repository contains a minimal React application powered by [Vite](https://v
 
 2. Start the development server:
    ```bash
-   npm run dev
+   npm start        # installs deps if missing
    # or
-   yarn dev
+   yarn start
+   # or
+   npm run dev
    ```
+
+Running `npm start` will automatically install dependencies the first time.
 
 3. Open your browser to the address printed in the console (usually `http://localhost:5173`). The page should display a blue circle rendered with D3.js.
 

--- a/package.json
+++ b/package.json
@@ -5,6 +5,8 @@
   "description": "A basic React setup with D3.js and other frontend libraries.",
   "scripts": {
     "dev": "vite",
+    "prestart": "node prestart.js",
+    "start": "vite",
     "build": "vite build",
     "preview": "vite preview"
   },

--- a/prestart.js
+++ b/prestart.js
@@ -1,0 +1,7 @@
+const { execSync } = require('child_process');
+try {
+  require.resolve('vite');
+} catch (err) {
+  console.log('Dependencies missing. Installing...');
+  execSync('npm install', { stdio: 'inherit' });
+}


### PR DESCRIPTION
## Summary
- create a `prestart.js` helper that runs `npm install` if dependencies are missing
- hook the script into the `prestart` lifecycle
- document that `npm start` installs missing deps automatically

## Testing
- `npm run build` *(fails: vite not installed)*