### PR TITLE
Add World metrics chart

### DIFF
--- a/README
+++ b/README
@@ -27,7 +27,7 @@ This repository contains a minimal React application powered by [Vite](https://v
 
 Running `npm start` will automatically install dependencies the first time.
 
-3. Open your browser to the address printed in the console (usually `http://localhost:5173`). The page should display a blue circle rendered with D3.js.
+3. Open your browser to the address printed in the console (usually `http://localhost:5173`). The page now displays a metrics chart showing the number of World IDs over time.
 
 ## Building for Production
 
@@ -47,6 +47,19 @@ npm run preview
 # or
 yarn preview
 ```
+
+## Metrics Source
+
+By default the app fetches metrics from `public/sample-data.json`. To query live
+data from [Dune Analytics](https://dune.com/) provide a query ID and API key in a
+`.env` file at the project root:
+
+```env
+VITE_DUNE_API_KEY=your_api_key
+```
+
+Update `DUNE_QUERY_ID` inside `src/WorldMetrics.jsx` with your query ID that
+returns daily `date`, `world_ids`, and `verified_ids` columns.
 
 ## Adding Other Libraries
 

--- a/public/sample-data.json
+++ b/public/sample-data.json
@@ -1,0 +1,9 @@
+[
+  { "date": "2024-05-01", "world_ids": 1000, "verified_ids": 100 },
+  { "date": "2024-05-02", "world_ids": 1100, "verified_ids": 140 },
+  { "date": "2024-05-03", "world_ids": 1200, "verified_ids": 170 },
+  { "date": "2024-05-04", "world_ids": 1300, "verified_ids": 210 },
+  { "date": "2024-05-05", "world_ids": 1400, "verified_ids": 260 },
+  { "date": "2024-05-06", "world_ids": 1500, "verified_ids": 310 },
+  { "date": "2024-05-07", "world_ids": 1600, "verified_ids": 370 }
+]

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,25 +1,13 @@
 import React from 'react';
-import * as d3 from 'd3';
 import './App.css';
+import WorldMetrics from './WorldMetrics';
 
 export default function App() {
-  React.useEffect(() => {
-    const svg = d3.select('#viz')
-      .append('svg')
-      .attr('width', 200)
-      .attr('height', 200);
-
-    svg.append('circle')
-      .attr('cx', 100)
-      .attr('cy', 100)
-      .attr('r', 80)
-      .attr('fill', 'steelblue');
-  }, []);
 
   return (
     <div className="App">
       <h1>WorldMetrics React + D3</h1>
-      <div id="viz"></div>
+      <WorldMetrics />
     </div>
   );
 }

--- a/src/WorldMetrics.jsx
+++ b/src/WorldMetrics.jsx
@@ -1,0 +1,88 @@
+import React from 'react';
+import * as d3 from 'd3';
+
+// Replace with your actual Dune Analytics query ID
+const DUNE_QUERY_ID = 'YOUR_QUERY_ID';
+
+async function fetchMetrics() {
+  const apiKey = import.meta.env.VITE_DUNE_API_KEY;
+  if (!apiKey) {
+    // Fallback to local sample data if no API key is provided
+    const resp = await fetch('/sample-data.json');
+    return resp.json();
+  }
+
+  const url = `https://api.dune.com/api/v1/query/${DUNE_QUERY_ID}/results?api_key=${apiKey}`;
+  const resp = await fetch(url);
+  if (!resp.ok) {
+    throw new Error('Failed to fetch metrics');
+  }
+  const data = await resp.json();
+  // Adjust this depending on Dune's response structure
+  return data.result?.rows || [];
+}
+
+export default function WorldMetrics() {
+  const [metrics, setMetrics] = React.useState([]);
+
+  React.useEffect(() => {
+    fetchMetrics().then(setMetrics).catch(err => {
+      console.error(err);
+    });
+  }, []);
+
+  React.useEffect(() => {
+    if (!metrics.length) return;
+
+    const parsed = metrics.map(d => ({
+      date: new Date(d.date),
+      world_ids: +d.world_ids,
+      verified_ids: +d.verified_ids
+    }));
+
+    const svg = d3.select('#metrics-chart');
+    svg.selectAll('*').remove();
+
+    const width = 500;
+    const height = 300;
+    const margin = { top: 20, right: 20, bottom: 30, left: 50 };
+
+    svg
+      .attr('width', width)
+      .attr('height', height);
+
+    const x = d3.scaleTime()
+      .domain(d3.extent(parsed, d => d.date))
+      .range([margin.left, width - margin.right]);
+
+    const y = d3.scaleLinear()
+      .domain([0, d3.max(parsed, d => d.world_ids)]).nice()
+      .range([height - margin.bottom, margin.top]);
+
+    const line = d3.line()
+      .x(d => x(d.date))
+      .y(d => y(d.world_ids));
+
+    svg.append('g')
+      .attr('transform', `translate(0,${height - margin.bottom})`)
+      .call(d3.axisBottom(x).ticks(width / 80).tickSizeOuter(0));
+
+    svg.append('g')
+      .attr('transform', `translate(${margin.left},0)`)
+      .call(d3.axisLeft(y));
+
+    svg.append('path')
+      .datum(parsed)
+      .attr('fill', 'none')
+      .attr('stroke', 'steelblue')
+      .attr('stroke-width', 1.5)
+      .attr('d', line);
+  }, [metrics]);
+
+  return (
+    <div>
+      <h2>World IDs Over Time</h2>
+      <svg id="metrics-chart"></svg>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- fetch World ID metrics from Dune (or local sample) and visualize
- display the chart in the app
- document metrics data source and env var in README

## Testing
- `npm install` *(fails: Exit handler never called)*
- `npm run build` *(fails: vite: not found)*